### PR TITLE
Fixing Issues 1 and 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ My aim is just to add some styling and modifaction for better aesthetics. These 
 To use this script, you need to install a userscript manager extension for your browser. Just choose according to your liking below:
 
 #### ScriptManager:
-* ![](https://raw.githubusercontent.com/reek/anti-adblock-killer/gh-pages/images/firefox.png) [Greasemonkey](https://addons.mozilla.org/firefox/addon/greasemonkey/) or Scriptish (Not supported/Addon has been discontinued)
+* ![](https://raw.githubusercontent.com/reek/anti-adblock-killer/gh-pages/images/firefox.png) [Greasemonkey](https://addons.mozilla.org/firefox/addon/greasemonkey/) , [Violentmonkey](https://addons.mozilla.org/firefox/addon/violentmonkey/) or Scriptish (Not supported/Addon has been discontinued)
 * ![](https://raw.githubusercontent.com/reek/anti-adblock-killer/gh-pages/images/chrome.png) [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo) or Native (Not supported)
 * ![](https://raw.githubusercontent.com/reek/anti-adblock-killer/gh-pages/images/opera.png) [Tampermonkey](https://addons.opera.com/extensions/details/tampermonkey-beta/) or [Violentmonkey](https://addons.opera.com/extensions/details/violent-monkey/) 
 * ![](https://raw.githubusercontent.com/reek/anti-adblock-killer/gh-pages/images/safari.png) [Tampermonkey](https://safari.tampermonkey.net/tampermonkey.safariextz) or [NinjaKit](https://github.com/os0x/NinjaKit)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Endless-Google-Improved
+Edit from Daeltam :
+Mix fork of tumpio's code and LoonerNinja
+1. I kept LoonerNinja's modifications except the function requestNextPage() that is the 0.0.8 version coming from tumpio; LoonerNinja's version is not working anymore.
+2. I added a line to hide "Related Searches" that were still appearing, reverting OnScrollDocumentEnd() to 0.0.8
+
 This is just my tiny fork of tumpio's original work from https://openuserjs.org/scripts/tumpio/Endless_Google.  
 My aim is just to add some styling and modifaction for better aesthetics. These changes/additions are the following:
 1. Removes the page navigation buttons at the bottom.
 2. Removes the repeating "Related searches" when the next page loads.
 3. Move the location bar from bottom to the topbar.
-4. Stop the infinite scrolling when there are no more results to load.
+4. Stop the infinite scrolling when there are no more results to load. --BROKEN-- 
 
 To use this script, you need to install a userscript manager extension for your browser. Just choose according to your liking below:
 

--- a/UserScript.js
+++ b/UserScript.js
@@ -26,6 +26,7 @@
 // This is Daeltam's Mix fork of tumpio's code and LoonerNinja
 // I kept LoonerNinja's modifications except the function requestNextPage() that is the 0.0.8 version coming from tumpio
 // LoonerNinja's version is not working anymore
+// And I added a line to hide "Related Searches" that were still appearing, reverting OnScrollDocumentEnd() to 0.0.8
 
 // NOTE: Don't run on image search
 if (location.href.indexOf("tbm=isch") !== -1){
@@ -156,23 +157,10 @@ function unescapeHex(hex) {
 function onScrollDocumentEnd() {
     let y = window.scrollY;
     let delta = y - prevScrollY;
-    let elem = document.querySelector('tr[jsname="TeSSVd"]').childNodes.length
-    if (!nextPageLoading && delta > 0 && isDocumentEnd(y) && elem > 0) {
+    if (!nextPageLoading && delta > 0 && isDocumentEnd(y)) {
         requestNextPage();
     }
     prevScrollY = y;
-    let allElems = document.querySelectorAll('*'), // Hides the repeating "Related searches" as the next page loads.
-    elems = [],
-    obj = {};
-    Array.from(allElems).forEach(v => v.getAttribute('class') ? elems.push(v) : null);
-    elems.forEach(v => {!obj[v.getAttribute('class')] ? obj[v.getAttribute('class')] = 1 : obj[v.getAttribute('class')]++});
-    Object.keys(obj).forEach(function(v) {
-        let elements = document.getElementsByClassName('oIk2Cb');
-        if (obj[v] > 1) {
-            Array.from(elements).forEach(v => {v.hidden = true});
-            elements[0].hidden = false;
-        }
-    });
 }
 
 function isDocumentEnd(y) {
@@ -219,3 +207,6 @@ document.addEventListener("DOMContentLoaded", init);
 
 // Hides the bottom page navigation bar.
 GM_addStyle(".AaVjTc { display: none !important; }");
+
+// Hides the "related searches" at the end of the page.
+GM_addStyle(".oIk2Cb { display: none !important;}");


### PR DESCRIPTION
Temporary fix for Issue #1 : Removed the functionnality 4 

> // 4. Stop the infinite scrolling when there are no more results to load. --Broken--

But enables the script to run because it doesn't trip on an error anymore

Fix for Issue #2 : Functionnality 2 working 

> // 2. Removes the repeating "Related searches" when the next page loads.

Changed the way the 'Related Searches' are hidden